### PR TITLE
Feature: One `omega-logger` module instance per process

### DIFF
--- a/logging.js
+++ b/logging.js
@@ -12,7 +12,8 @@ if(!process.$_omega_logger)
 
     // ----------------------------------------------------------------------------------------------------------------
 
-    var logging = {
+    // Set the process-wide `$_omega_logger` property so we don't create the module multiple times.
+    var logging = module.exports = process.$_omega_logger = {
         levels: [
             'TRACE',
             'DEBUG',
@@ -189,10 +190,9 @@ if(!process.$_omega_logger)
                 handlers: [logging.defaultConsoleHandler]
             });
 
-    // ----------------------------------------------------------------------------------------------------------------
-
-    // Set the process-wide `$_omega_logger` property so we don't create the module multiple times.
-    process.$_omega_logger = logging;
+}
+else
+{
+    // omega-logger has already been initialized; just export the existing module.
+    module.exports = process.$_omega_logger;
 } // end if
-
-module.exports = process.$_omega_logger;


### PR DESCRIPTION
Modified main module so it doesn't set things up more than once per process, even if installed in multiple places.

This should fix configuration issues when `omega-logger` is depended on by multiple packages in the same hierarchy.

(sorry for the messy-looking diff; the entire file had to be indented, and I don't see a way to make GitHub ignore whitespace in diffs)
