### PR TITLE
Logger tree speedup

### DIFF
--- a/lib/HasLevel.js
+++ b/lib/HasLevel.js
@@ -26,7 +26,7 @@ function HasLevel()
 Object.defineProperty(HasLevel.prototype, 'level', {
     get: function()
     {
-        return this._level;
+        return logging.levels[this._levelIdx];
     }, // end get
     set: function(value)
     {
@@ -54,7 +54,6 @@ Object.defineProperty(HasLevel.prototype, 'levelIdx', {
         } // end if
 
         this._levelIdx = value;
-        this._level = logging.levels[this._levelIdx];
     } // end set
 }); // end HasLevel#levelIdx
 

--- a/lib/HasLevel.js
+++ b/lib/HasLevel.js
@@ -19,7 +19,7 @@ function HasLevel()
 /**
  * Get or set the name of this object's current logging level.
  *
- * `undefined` is used if no level (or an invalid one) is set.
+ * `undefined` is used if no level is set.
  *
  * @member {string} HasLevel#level
  */
@@ -37,7 +37,7 @@ Object.defineProperty(HasLevel.prototype, 'level', {
 /**
  * Get or set the index of this object's current logging level.
  *
- * `-1` is used if no level (or an invalid one) is set.
+ * `-1` is used if no level is set.
  *
  * @member {number} HasLevel#levelIdx
  */

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -26,7 +26,13 @@ var HasLevel = require('./HasLevel');
  */
 function Logger(name, config)
 {
-    // Read-only 'name' property
+    /**
+     * The name of this logger.
+     *
+     * This is a read-only property.
+     *
+     * @member {string} module:logging.Logger#name
+     */
     Object.defineProperty(this, 'name', {value: name, configurable: false, enumerable: true, writable: false});
 
     this.propagate = true;
@@ -46,7 +52,13 @@ function Logger(name, config)
         parent = logging.getLogger(name.slice(0, lastDot));
     } // end if
 
-    // Read-only 'parent' property
+    /**
+     * The parent of this logger.
+     *
+     * This is a read-only property.
+     *
+     * @member {module:logging.Logger} module:logging.Logger#parent
+     */
     Object.defineProperty(this, 'parent', {value: parent, configurable: false, enumerable: true, writable: false});
 
     HasLevel.apply(this);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -214,7 +214,7 @@ Logger.prototype.silence = function()
 /**
  * Un-silence this logger.
  *
- * Note: This will have _no apparent effect_ if this logger has been silenced due to calling
+ * Note: This will have _no apparent effect_ if this logger has been silenced due to calling the package-wide
  * {@linkcode module:logging.silence}; this _only_ affects the logger-specific flag set by
  * {@linkcode module:logging.Logger#silence}.
  *

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -31,6 +31,24 @@ function Logger(name, config)
 
     this.propagate = true;
 
+    var parent;
+    var lastDot = name.lastIndexOf('.');
+    if(name == 'root')
+    {
+        parent = {};
+    }
+    else if(lastDot == -1)
+    {
+        parent = logging.root;
+    }
+    else
+    {
+        parent = logging.getLogger(name.slice(0, lastDot));
+    } // end if
+
+    // Read-only 'parent' property
+    Object.defineProperty(this, 'parent', {value: parent, configurable: false, enumerable: true, writable: false});
+
     HasLevel.apply(this);
 
     this.configure(config);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -158,6 +158,8 @@ Object.defineProperty(Logger.prototype, '_levelIdx', {
  * Configure this logger.
  *
  * @param {object} config - updates to apply to the configuration of this logger
+ *
+ * @return {module:logging.Logger} this logger
  */
 Logger.prototype.configure = function(config)
 {
@@ -168,6 +170,8 @@ Logger.prototype.configure = function(config)
             this[key] = config[key];
         } // end if
     } // end for
+
+    return this;
 }; // end Logger#configure
 
 /**

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -94,14 +94,19 @@ Logger.prototype._silenced = false;
 Object.defineProperty(Logger.prototype, 'handlers', {
     'get': function()
     {
-        return this.accumInherited('_handlers', function(logger)
+        var handlers = this._handlers || [];
+        if(!Array.isArray(handlers))
         {
-            if(logger.propagate)
-            {
-                // This logger is set to not propagate any messages to its ancestors; stop after processing it.
-                return 'stopAfter';
-            } // end if
-        });
+            handlers = [handlers];
+        } // end if
+
+        if(this.propagate)
+        {
+            // This logger is set to propagate messages to its ancestors; add the parent logger's handlers.
+            return handlers.concat(this.parent.handlers);
+        } // end if
+
+        return handlers;
     }, // end get
     'set': function(value)
     {
@@ -119,7 +124,23 @@ Object.defineProperty(Logger.prototype, 'handlers', {
 Object.defineProperty(Logger.prototype, '_levelIdx', {
     get: function()
     {
-        return this.getInherited('__levelIdx', true) || -1;
+        var levelIdx = this.__levelIdx;
+        if(levelIdx !== undefined)
+        {
+            return levelIdx;
+        }
+        else
+        {
+            levelIdx = this.parent.__levelIdx;
+            if(levelIdx !== undefined)
+            {
+                return levelIdx;
+            }
+            else
+            {
+                return -1;
+            } // end if
+        } // end if
     }, // end get
     set: function(value)
     {
@@ -371,105 +392,6 @@ Logger.setLogMethods = function()
  * @return {module:logging.Logger} this logger
  */
 Logger.setLogMethods();
-
-/**
- * Get the inherited value of the given key for this logger.
- *
- * Starting with this logger, this traverses up the logger hierarchy until a logger with a value for the given
- * key is found.
- *
- * @param {string} key - the name of the key to look for
- * @param {boolean} [ignoreNull] - if `true`, count `null` as a valid value (by default, `null` and `undefined` are both
- *          ignored when searching for values)
- *
- * @returns {*} the inherited value of `key` for this logger
- */
-Logger.prototype.getInherited = function(key, nullIsValue)
-{
-    var value = this[key];
-    if(value !== undefined && (nullIsValue || value !== null))
-    {
-        return value;
-    } // end if
-
-    var splitLoggerName = this.name.split('.');
-    while(splitLoggerName.length > 1)
-    {
-        splitLoggerName.pop();
-        var ancestorLogger = logging.namedLoggers[splitLoggerName.join('.')];
-
-        if(ancestorLogger)
-        {
-            value = ancestorLogger[key];
-            if(value !== undefined && (nullIsValue || value !== null))
-            {
-                return value;
-            } // end if
-        } // end if
-    } // end while
-
-    // If we haven't found a value for the given key yet, return it from the root logger.
-    return logging.root[key];
-}; // end Logger#getInherited
-
-/**
- * Accumulate inherited values of the given key from this logger and all its ancestors into an array.
- *
- * Starting with this logger, this traverses up the logger hierarchy, accumulating all values for the given
- * key from each logger. If `stopCondition` is given, the traversal will stop when that function returns `"stopBefore"`
- * or `"stopAfter"` for a given logger.
- *
- * @param {string} key - the name of the key to look for
- * @param {function(module:logging.Logger):boolean} [stopCondition] - if provided, will be called for each logger
- *          encountered; traversal will stop _before_ processing the given logger if `"stopBefore"` is returned, or
- *          _after_ processing if `"stopAfter"` is returned
- *
- * @returns {Array.<*>} the accumulated values of `key` for this logger
- */
-Logger.prototype.accumInherited = function(key, stopCondition)
-{
-    var values;
-
-    var accum = this[key] || [];
-    if(!Array.isArray(accum))
-    {
-        accum = [accum];
-    } // end if
-
-    if(this.name == 'root')
-    {
-        return accum;
-    } // end if
-
-    var splitLoggerName = this.name.split('.');
-    while(splitLoggerName.length > 1)
-    {
-        splitLoggerName.pop();
-        var ancestorLogger = logging.namedLoggers[splitLoggerName.join('.')];
-
-        if(ancestorLogger)
-        {
-            var stopIndicator = stopCondition ? stopCondition(ancestorLogger) : null;
-            if(stopIndicator == "stopBefore") { return accum; }
-
-            values = ancestorLogger[key];
-            if(values)
-            {
-                accum = accum.concat(values);
-            } // end if
-
-            if(stopIndicator == "stopAfter") { return accum; }
-        } // end if
-    } // end while
-
-    values = logging.root[key];
-    if(values)
-    {
-        accum = accum.concat(values);
-    } // end if
-
-    return accum;
-}; // end Logger#accumInherited
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -33,13 +33,7 @@ function Logger(name, config)
 
     HasLevel.apply(this);
 
-    for(var key in config)
-    {
-        if(config.hasOwnProperty(key))
-        {
-            this[key] = config[key];
-        } // end if
-    } // end for
+    this.configure(config);
 } // end Logger
 
 util.inherits(Logger, HasLevel);
@@ -141,6 +135,22 @@ Object.defineProperty(Logger.prototype, '_levelIdx', {
 }); // end Logger#_levelIdx
 
 // --------------------------------------------------------------------------------------------------------------------
+
+/**
+ * Configure this logger.
+ *
+ * @param {object} config - updates to apply to the configuration of this logger
+ */
+Logger.prototype.configure = function(config)
+{
+    for(var key in config)
+    {
+        if(config.hasOwnProperty(key))
+        {
+            this[key] = config[key];
+        } // end if
+    } // end for
+}; // end Logger#configure
 
 /**
  * Log a message using this logger.

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -110,24 +110,6 @@ Object.defineProperty(Logger.prototype, 'handlers', {
 }); // end Logger#handlers
 
 /**
- * Look up the current inherited level name using the logger hierarchy.
- *
- * @member {string} Logger#_level
- * @private
- * @see {HasLevel#level}
- */
-Object.defineProperty(Logger.prototype, '_level', {
-    get: function()
-    {
-        return this.getInherited('__level', true);
-    }, // end get
-    set: function(value)
-    {
-        this.__level = value;
-    } // end set
-}); // end Logger#_level
-
-/**
  * Look up the current inherited level index using the logger hierarchy.
  *
  * @member {number} Logger#_levelIdx

--- a/logging.js
+++ b/logging.js
@@ -276,15 +276,18 @@ else
      */
     logging.defaultConsoleHandler = new logging.handlers.Console({level: defaultLevel});
 
-    /**
-     * The root logger.
-     *
-     * @member {module:logging.Logger} module:logging.root
-     */
-    logging.root = new logging.Logger('root', {
+    var rootLogger = new logging.Logger('root', {
         propagate: false,
         handlers: [logging.defaultConsoleHandler]
     });
+    /**
+     * The root logger.
+     *
+     * This is a read-only property.
+     *
+     * @member {module:logging.Logger} module:logging.root
+     */
+    Object.defineProperty(this, 'root', {value: rootLogger, configurable: false, enumerable: true, writable: false});
 
     // ----------------------------------------------------------------------------------------------------------------
 

--- a/logging.js
+++ b/logging.js
@@ -285,7 +285,7 @@ else
      *
      * @member {module:logging.Logger} module:logging.root
      */
-    Object.defineProperty(this, 'root', {value: rootLogger, configurable: false, enumerable: true, writable: false});
+    Object.defineProperty(logging, 'root', {value: rootLogger, configurable: false, enumerable: true, writable: false});
 
     // ----------------------------------------------------------------------------------------------------------------
 

--- a/logging.js
+++ b/logging.js
@@ -112,10 +112,7 @@ else
          */
         getLogger: function getLogger(name)
         {
-            if(!name)
-            {
-                return logging.root;
-            } // end if
+            name = name || 'root';
 
             var logger = logging.namedLoggers[name];
             if(!logger)

--- a/logging.js
+++ b/logging.js
@@ -280,6 +280,7 @@ else
         propagate: false,
         handlers: [logging.defaultConsoleHandler]
     });
+
     /**
      * The root logger.
      *

--- a/logging.js
+++ b/logging.js
@@ -273,10 +273,11 @@ else
      */
     logging.defaultConsoleHandler = new logging.handlers.Console({level: defaultLevel});
 
-    var rootLogger = new logging.Logger('root', {
-        propagate: false,
-        handlers: [logging.defaultConsoleHandler]
-    });
+    var rootLogger = logging.getLogger('root')
+        .configure({
+            propagate: false,
+            handlers: [logging.defaultConsoleHandler]
+        });
 
     /**
      * The root logger.


### PR DESCRIPTION
I've had this sitting around for quite a while, but it should really get merged.

This speeds up the process of getting properties from ancestor loggers significantly.

It also:
- adds `Logger#configure()`, which lets us change the configuration of a logger easily after it's instantiated
- makes `logging.root` a read-only property
- adds the root logger to `logging.namedLoggers`, so it can be looked up with `logging.getLogger('root')`
- fixes/updates/clarifies several doc comments
- probably fixes several issues with logger propagation

### Long-winded explanation ###
Previously, we looped over all loggers to find ones that had a name that was a prefix of the current logger's name, and either returned the property of the closest ancestor that set it, or accumulated the values from all ancestor loggers into a list. Now, at logger instantiation time, we look up the direct parent of the new logger (creating it if it doesn't exist) and we just reference the parent logger directly for lookups. (the distinction between returning the closest defined value or an accumulated value is then just an implementation detail of the property we're looking for)