### PR TITLE
Feature: dumper options

### DIFF
--- a/lib/dumper.js
+++ b/lib/dumper.js
@@ -13,10 +13,10 @@ var util = require('util');
  * @constructor
  *
  * @param {*} target - the object to dump
- * @param {?number} depth - the maximum depth to display; specify `0` to show only _top-level_ properties, or specify
- *          `-1` or `null` for unlimited depth
+ * @param {(number|object)} [depthOrOptions] - the maximum depth to display, or an options object for `util.inspect()`;
+ *          specify `0` to show only _top-level_ properties, or specify `-1` or `null` for unlimited depth
  */
-function Dumper(target, depth)
+function Dumper(target, depthOrOptions)
 {
     /**
      * The object to dump.
@@ -39,7 +39,14 @@ function Dumper(target, depth)
     // Make an initial `inspectOpts` object.
     this._inspectOpts = Object.create(this.persistentInspectOpts);
 
-    this.depth = depth;
+    if(typeof depthOrOptions == 'object' && depthOrOptions !== null)
+    {
+        this.inspectOpts = depthOrOptions;
+    }
+    else
+    {
+        this.depth = depthOrOptions;
+    } // end if
 } // end Dumper
 
 /**
@@ -77,7 +84,7 @@ Object.defineProperty(Dumper.prototype, 'inspectOpts', {
             this._inspectOpts[key] = inspectOpts[key];
         } // end for
     } // end set
-}); // end Dumper#depth
+}); // end Dumper#inspectOpts
 
 /**
  * The maximum depth to display.


### PR DESCRIPTION
Dumper now takes either a depth value _or_ an options object for `util.inspect()`.