### PR TITLE
Unit tests, and bugfix for incorrect levelIdx

### DIFF
--- a/lib/HasLevel.js
+++ b/lib/HasLevel.js
@@ -11,7 +11,6 @@ var logging = require('../logging');
  */
 function HasLevel()
 {
-    Object.defineProperty(this, '_levelIdx', {'value': -1, 'enumerable': false, 'writable': true});
 } // end HasLevel
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -34,6 +33,14 @@ Object.defineProperty(HasLevel.prototype, 'level', {
     }, // end set
     enumerable: true
 }); // end HasLevel#level
+
+/**
+ * The private value that stores this object's current logging level.
+ * @private
+ *
+ * @member {number} HasLevel#levelIdx
+ */
+Object.defineProperty(HasLevel.prototype, '_levelIdx', {'value': -1, 'enumerable': false, 'writable': true});
 
 /**
  * Get or set the index of this object's current logging level.

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -137,22 +137,15 @@ Object.defineProperty(Logger.prototype, '_levelIdx', {
     get: function()
     {
         var levelIdx = this.__levelIdx;
-        if(levelIdx !== undefined)
+        if(levelIdx === undefined)
         {
-            return levelIdx;
-        }
-        else
-        {
-            levelIdx = this.parent.__levelIdx;
-            if(levelIdx !== undefined)
-            {
-                return levelIdx;
-            }
-            else
-            {
-                return -1;
-            } // end if
+            levelIdx = this.parent._levelIdx;
         } // end if
+        if(levelIdx === undefined)
+        {
+            levelIdx = -1;
+        } // end if
+        return levelIdx;
     }, // end get
     set: function(value)
     {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {},
   "main": "logging.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -20,5 +20,9 @@
   "contributors": [
     "David H. Bronke <whitelynx@gmail.com>"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "chai": "^3.3.0",
+    "mocha": "^2.3.3"
+  }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,8 @@
+// --------------------------------------------------------------------------------------------------------------------
+// Chai configuration
+
+var chai = require('chai');
+
+chai.config.truncateThreshold = 0;
+
+global.expect = chai.expect;

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -1,0 +1,103 @@
+/* global describe: true, it: true, expect: true */
+
+var logging = require('../logging.js');
+
+
+describe('Logger', function()
+{
+    describe('#parent', function()
+    {
+        describe('on the root logger', function()
+        {
+            it('should be set to an empty object', function()
+            {
+                var logger = logging.getLogger();
+
+                expect(logger.parent)
+                    .to.be.an('object')
+                    .that.deep.equals({});
+            });
+        });
+
+        describe('on any other logger', function()
+        {
+            it('should be set to this Logger\'s parent', function()
+            {
+                var logger = logging.getLogger('test1.child');
+
+                expect(logger.parent).to.equal(logging.getLogger('test1'));
+            });
+        });
+    });
+
+    describe('#levelIdx', function()
+    {
+        it('should be settable', function()
+        {
+            var logger = logging.getLogger('test1');
+            logger.levelIdx = 4;
+
+            expect(logger.levelIdx).to.equal(4);
+        });
+
+        it('should be settable through #configure()', function()
+        {
+            var logger = logging.getLogger('test3');
+            logger.configure({ levelIdx: 5 });
+
+            expect(logger.levelIdx).to.equal(5);
+        });
+
+        it('should be inherited from the parent Logger if unset on this', function()
+        {
+            var parentLogger = logging.getLogger('test4');
+            parentLogger.levelIdx = 5;
+
+            var logger = parentLogger.child('child');
+
+            expect(parentLogger.levelIdx).to.equal(5);
+            expect(logger.levelIdx).to.equal(parentLogger.levelIdx);
+        });
+
+        it('should not be inherited from the parent Logger if set on this', function()
+        {
+            var parentLogger = logging.getLogger('test5');
+            parentLogger.levelIdx = 4;
+
+            var logger = parentLogger.child('child');
+            logger.levelIdx = 3;
+
+            expect(parentLogger.levelIdx).to.equal(4);
+            expect(logger.levelIdx).to.equal(3);
+        });
+
+        it('should be inherited from the grandparent Logger if unset on this or parent', function()
+        {
+            var grandparentLogger = logging.getLogger('test6');
+            grandparentLogger.levelIdx = 2;
+
+            var parentLogger = grandparentLogger.child('parent');
+
+            var logger = parentLogger.child('child');
+
+            expect(grandparentLogger.levelIdx).to.equal(2);
+            expect(parentLogger.levelIdx).to.equal(grandparentLogger.levelIdx);
+            expect(logger.levelIdx).to.equal(grandparentLogger.levelIdx);
+        });
+
+        it('should not be inherited from the grandparent Logger if set on this', function()
+        {
+            var grandparentLogger = logging.getLogger('test7');
+            grandparentLogger.levelIdx = 1;
+
+            var parentLogger = grandparentLogger.child('parent');
+
+            var logger = parentLogger.child('child');
+            logger.levelIdx = 0;
+
+            expect(grandparentLogger.levelIdx).to.equal(1);
+            expect(parentLogger.levelIdx).to.equal(grandparentLogger.levelIdx);
+            expect(logger.levelIdx).to.equal(0);
+        });
+    });
+});

--- a/test/logging.spec.js
+++ b/test/logging.spec.js
@@ -1,0 +1,17 @@
+/* global describe: true, it: true, expect: true */
+
+var logging = require('../logging.js');
+
+
+describe('logging', function()
+{
+    describe('.getLogger()', function()
+    {
+        it('should return the same Logger instance if called multiple times with the same name', function()
+        {
+            var logger = logging.getLogger('test1');
+
+            expect(logger).to.equal(logging.getLogger('test1'));
+        });
+    });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--reporter spec
+--require test/common


### PR DESCRIPTION
Added several unit tests, and fixed two bugs (in `HasLevel` and `Logger#_levelIdx`) that caused `levelIdx` to not be inherited as expected through the `Logger` hierarchy.