### PR TITLE
Feature: Extra data

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -98,6 +98,16 @@ Context.prototype.toJSON = function()
     return serialized;
 }; // end Context#toJSON
 
+/**
+ * Assign extra data properties to this context.
+ *
+ * Extra data properties will NOT be displayed by the console handler by default, but will be shown when `LOG_AS_JSON`
+ * is enabled, and will also be available to all other handlers.
+ *
+ * @param {object} extraProperties - an object defining the extra properties to assign
+ *
+ * @returns {Context} `this`, for chaining
+ */
 Context.prototype.assign = function(extraProperties)
 {
     return assign(this, extraProperties);

--- a/lib/context.js
+++ b/lib/context.js
@@ -15,13 +15,13 @@ var HasLevel = require('./HasLevel');
 
 var datetimeSplitRE = /T/;
 
-// Allow extra properties to be assigned to log messages.
-var extraLogData = {};
+// Allow extra properties to be assigned to all log messages.
+var globalLogData = {};
 if(process.env.LOG_MSG_DATA)
 {
     try
     {
-        extraLogData = JSON.parse(process.env.LOG_MSG_DATA);
+        globalLogData = JSON.parse(process.env.LOG_MSG_DATA);
     }
     catch(exc)
     {
@@ -49,9 +49,9 @@ function Context(logger, levelIdx, message, args)
     HasLevel.apply(this);
 
     // Assign any extra log data that was given.
-    for(var key in extraLogData)
+    for(var key in globalLogData)
     {
-        this[key] = extraLogData[key];
+        this[key] = globalLogData[key];
     } // end for
 
     this.logger = logger;

--- a/lib/context.js
+++ b/lib/context.js
@@ -29,6 +29,20 @@ if(process.env.LOG_MSG_DATA)
     } // end try
 } // end if
 
+function assign(target)
+{
+    var sources = Array.prototype.slice.call(arguments, 1);
+    for(var sourceIdx = 0; sourceIdx < sources.length; sourceIdx++)
+    {
+        var source = sources[sourceIdx];
+        for(var key in source)
+        {
+            target[key] = source[key];
+        } // end for
+    } // end for
+    return target;
+} // end assign
+
 // --------------------------------------------------------------------------------------------------------------------
 
 /**
@@ -48,11 +62,8 @@ function Context(logger, levelIdx, message, args)
 {
     HasLevel.apply(this);
 
-    // Assign any extra log data that was given.
-    for(var key in globalLogData)
-    {
-        this[key] = globalLogData[key];
-    } // end for
+    // Assign any global log data that was given.
+    assign(this, globalLogData);
 
     this.logger = logger;
     this.levelIdx = levelIdx;
@@ -99,6 +110,11 @@ Context.prototype.toJSON = function()
     } // end for
     return serialized;
 }; // end Context#toJSON
+
+Context.prototype.assign = function(extraProperties)
+{
+    return assign(this, extraProperties);
+}; // end Context#assign
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -7,6 +7,7 @@ var util = require('util');
 
 var logging = require('../logging');
 
+var assign = require('../util/assign');
 var stack = require('../util/stack');
 
 var HasLevel = require('./HasLevel');
@@ -28,20 +29,6 @@ if(process.env.LOG_MSG_DATA)
         console.warn("Error parsing LOG_MSG_DATA from environment: %s", exc.stack || exc);
     } // end try
 } // end if
-
-function assign(target)
-{
-    var sources = Array.prototype.slice.call(arguments, 1);
-    for(var sourceIdx = 0; sourceIdx < sources.length; sourceIdx++)
-    {
-        var source = sources[sourceIdx];
-        for(var key in source)
-        {
-            target[key] = source[key];
-        } // end for
-    } // end for
-    return target;
-} // end assign
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -16,7 +16,13 @@ var HasLevel = require('./HasLevel');
 
 var datetimeSplitRE = /T/;
 
-// Allow extra properties to be assigned to all log messages.
+/**
+ * Extra properties to be assigned to all log messages.
+ *
+ * Populated from the `LOG_MSG_DATA` environment variable.
+ *
+ * @see {@linkcode Context#assign}
+ */
 var globalLogData = {};
 if(process.env.LOG_MSG_DATA)
 {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -176,6 +176,7 @@ Object.defineProperty(Logger.prototype, '_levelIdx', {
  *
  * @member {number} Logger#extraData
  * @readonly
+ * @see {@linkcode Context#assign}
  */
 Object.defineProperty(Logger.prototype, 'extraData', {
     get: function()
@@ -224,6 +225,8 @@ Logger.prototype.configure = function(config)
  *
  * Extra data properties will NOT be displayed by the console handler by default, but will be shown when `LOG_AS_JSON`
  * is enabled, and will also be available to all other handlers.
+ *
+ * @see {@linkcode Context#assign}
  *
  * @param {object} extraProperties - an object defining the extra properties to assign
  *

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,6 +9,8 @@ var logging = require('../logging');
 var Context = require('./context');
 var HasLevel = require('./HasLevel');
 
+var assign = require('../util/assign');
+
 // --------------------------------------------------------------------------------------------------------------------
 
 /**
@@ -36,6 +38,8 @@ function Logger(name, config)
     Object.defineProperty(this, 'name', {value: name, configurable: false, enumerable: true, writable: false});
 
     this.propagate = true;
+
+    this.extraData = {};
 
     var parent;
     var lastDot = name.lastIndexOf('.');
@@ -167,6 +171,19 @@ Object.defineProperty(Logger.prototype, '_levelIdx', {
     } // end set
 }); // end Logger#_levelIdx
 
+/**
+ * Look up the complete set of actual and inherited extra data using the logger hierarchy.
+ *
+ * @member {number} Logger#extraData
+ * @readonly
+ */
+Object.defineProperty(Logger.prototype, 'extraData', {
+    get: function()
+    {
+        return assign({}, this._extraData, this.parent.extraData);
+    } // end get
+}); // end Logger#extraData
+
 // --------------------------------------------------------------------------------------------------------------------
 
 /**
@@ -182,12 +199,40 @@ Logger.prototype.configure = function(config)
     {
         if(config.hasOwnProperty(key))
         {
-            this[key] = config[key];
+            if(typeof this[key] == 'object' && this[key] !== null &&
+                    typeof config[key] == 'object' && config[key] !== null)
+            {
+                // The given key has already been set to an object; assign the incoming object's properties to the
+                // existing object.
+                assign(this[key], config[key]);
+            }
+            else
+            {
+                this[key] = config[key];
+            } // end if
         } // end if
     } // end for
 
     return this;
 }; // end Logger#configure
+
+/**
+ * Assign extra data properties to this logger.
+ *
+ * Extra data assigned to a logger will be inherited by all {@linkcode Context} instances (log message events) created
+ * by this logger.
+ *
+ * Extra data properties will NOT be displayed by the console handler by default, but will be shown when `LOG_AS_JSON`
+ * is enabled, and will also be available to all other handlers.
+ *
+ * @param {object} extraProperties - an object defining the extra properties to assign
+ *
+ * @returns {Logger} `this`, for chaining
+ */
+Logger.prototype.assign = function(extraProperties)
+{
+    return assign(this._extraData, extraProperties);
+}; // end Logger#assign
 
 /**
  * Log a message using this logger.
@@ -211,7 +256,8 @@ Logger.prototype.log = function log(level, message)//, ...args)
     var levelIdx = logging.getLevelIdx(level);
     if(levelIdx >= this.levelIdx)
     {
-        var context = new Context(this.name, levelIdx, message, Array.prototype.slice.call(arguments, 2));
+        var context = new Context(this.name, levelIdx, message, Array.prototype.slice.call(arguments, 2))
+            .assign(this.extraData);
 
         this.handlers.forEach(function eachHandler(handler)
         {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -172,18 +172,36 @@ Object.defineProperty(Logger.prototype, '_levelIdx', {
 }); // end Logger#_levelIdx
 
 /**
- * Look up the complete set of actual and inherited extra data using the logger hierarchy.
+ * Extra data properties to be attached to messages from this logger.
+ *
+ * Extra data assigned to a logger will be inherited by all {@linkcode Context} instances (log message events) created
+ * by this logger.
+ *
+ * Extra data properties will NOT be displayed by the console handler by default, but will be shown when `LOG_AS_JSON`
+ * is enabled, and will also be available to all other handlers.
  *
  * @member {number} Logger#extraData
  * @readonly
  * @see {@linkcode Context#assign}
  */
-Object.defineProperty(Logger.prototype, 'extraData', {
+Object.defineProperty(Logger.prototype, 'extraData', {'value': {}, 'enumerable': false, 'writable': true});
+
+/**
+ * Look up the complete set of actual and inherited extra data using the logger hierarchy.
+ *
+ * Properties set in this instance's {@linkcode Logger#extraData|extraData} override properties of the same name set in
+ * an ancestor logger.
+ *
+ * @member {number} Logger#combinedExtraData
+ * @readonly
+ * @see {@linkcode Context#assign}
+ */
+Object.defineProperty(Logger.prototype, 'combinedExtraData', {
     get: function()
     {
-        return assign({}, this._extraData, this.parent.extraData);
+        return assign({}, this.parent.extraData, this.extraData);
     } // end get
-}); // end Logger#extraData
+}); // end Logger#combinedExtraData
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -216,26 +234,6 @@ Logger.prototype.configure = function(config)
 
     return this;
 }; // end Logger#configure
-
-/**
- * Assign extra data properties to this logger.
- *
- * Extra data assigned to a logger will be inherited by all {@linkcode Context} instances (log message events) created
- * by this logger.
- *
- * Extra data properties will NOT be displayed by the console handler by default, but will be shown when `LOG_AS_JSON`
- * is enabled, and will also be available to all other handlers.
- *
- * @see {@linkcode Context#assign}
- *
- * @param {object} extraProperties - an object defining the extra properties to assign
- *
- * @returns {Logger} `this`, for chaining
- */
-Logger.prototype.assign = function(extraProperties)
-{
-    return assign(this._extraData, extraProperties);
-}; // end Logger#assign
 
 /**
  * Log a message using this logger.

--- a/util/assign.js
+++ b/util/assign.js
@@ -1,0 +1,19 @@
+// --------------------------------------------------------------------------------------------------------------------
+/// Assign the properties of one or more objects to a target object.
+///
+/// @module
+// --------------------------------------------------------------------------------------------------------------------
+
+module.exports = function assign(target)
+{
+    var sources = Array.prototype.slice.call(arguments, 1);
+    for(var sourceIdx = 0; sourceIdx < sources.length; sourceIdx++)
+    {
+        var source = sources[sourceIdx];
+        for(var key in source)
+        {
+            target[key] = source[key];
+        } // end for
+    } // end for
+    return target;
+}; // end assign


### PR DESCRIPTION
This adds the ability to add extra data to all log messages generated by a given `Logger` instance (or its descendants), similar to the `LOG_MSG_DATA` environment variable.

Any extra data that is set will be available to all handlers, but currently is _only_ handled by `ConsoleHandler`, and only when the `LOG_AS_JSON` environment variable is enabled.