### PR TITLE
Use a WeakMap to track existing named loggers.

### DIFF
--- a/logging.js
+++ b/logging.js
@@ -50,7 +50,7 @@ else
         ],
 
         handlers: {},
-        namedLoggers: {},
+        namedLoggers: new WeakMap(),
 
         // ------------------------------------------------------------------------------------------------------------
         // Functions
@@ -118,15 +118,17 @@ else
         {
             name = name || 'root';
 
-            var logger = logging.namedLoggers[name];
-            if(!logger)
+            if(logging.namedLoggers.has(name))
+            {
+                return logging.namedLoggers.get(name);
+            }
+            else
             {
                 // This logger doesn't exist; make a new one.
-                logger = new logging.Logger(name);
-                logging.namedLoggers[name] = logger;
+                var logger = new logging.Logger(name);
+                logging.namedLoggers.set(name, logger);
+                return logger;
             } // end if
-
-            return logger;
         }, // end getLogger
 
         /**


### PR DESCRIPTION
This allows `Logger` instances to be garbage collected when the calling code loses its reference.

This change requires either Node.js v0.12 or newer, or Node.js v0.10 with the `--harmony_collections` flag.