### PR TITLE
Bug: Fix named loggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "omega-logger",
   "version": "0.7.0",
   "description": "A simple, yet powerful logging system for omega-node.",
-  "dependencies": {},
+  "dependencies": {
+    "weak": "^1.0.0"
+  },
   "engines": {
     "node": ">=0.12"
   },


### PR DESCRIPTION
Since ES6's `WeakMap` requires that keys be _objects_ for some weird reason, it would throw a TypeError whenever you tried using `logging.getLogger()`... which broke everything.

This change switches from the ES6 `WeakMap` class to an object that stores `WeakRef` objects from the [`weak`](https://www.npmjs.com/package/weak) package.
